### PR TITLE
Dataset carousel

### DIFF
--- a/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
+++ b/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
@@ -62,13 +62,13 @@ export default {
     };
   },
   mounted: function() {
-    this.$http.get("/api/featured").then(
+    this.$http.get("https://api.blackfynn.io/discover/datasets?limit=5&offset=0").then(
       function(response) {
         const component = this;
 
-        this.featured = response.data;
+        this.featured = response.data.datasets;
         this.current = 0;
-        this.numElements = response.data.length;
+        this.numElements = response.data.datasets.length;
 
         const scheduleTimeout = () => {
           setTimeout(() => {

--- a/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
+++ b/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
@@ -12,7 +12,7 @@
             class="featured-dataset-image"
             :style="{ backgroundImage: `url('${dataset.banner}')` }"
           ></div>
-        </el-col>\
+        </el-col>
         <el-col :span="12" class="flush-column">
           <div class="featured-dataset-description">
             <div class="content">

--- a/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
+++ b/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
@@ -12,14 +12,16 @@
             class="featured-dataset-image"
             :style="{ backgroundImage: `url('${dataset.banner}')` }"
           ></div>
-        </el-col>
+        </el-col>\
         <el-col :span="12" class="flush-column">
           <div class="featured-dataset-description">
             <div class="content">
               <h2>{{ dataset.name }}</h2>
               <p>{{ dataset.description }}</p>
               <div class="actions">
+              <a :href="`/browse/#/datasets/${dataset.id}`">
                 <el-button type="primary" class="view-dataset">View dataset</el-button>
+              </a>
               </div>
             </div>
           </div>
@@ -43,7 +45,7 @@
 </template>
 
 <script>
-const SLIDE_DURATION = 5000;
+const SLIDE_DURATION = 4000;
 
 export default {
   name: "carousel",
@@ -135,6 +137,7 @@ export default {
 
     h2 {
       font-size: 1.5em;
+      word-break: break-all;
     }
 
     p {


### PR DESCRIPTION
# Description

The purpose of this PR is to add a dataset carousel to the homepage and allow users to explore the details page for each dataset.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the homepage and scroll to the bottom. You should see the carousel.
2. The carousel should only contain and loop through the first five datasets. You can verify this by going to the network tab and filtering by the `/datasets?limit=5&offset=0` to see that there are only five datasets in the response.
3. Click on `View Dataset` in the carousel. You should be navigated to the details page for that dataset.
4. Wait for the carousel to change and click on the `View Dataset` button again. You should be navigated to that dataset details page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
