### PR TITLE
Allow user to use ticks to navigate carousel

### DIFF
--- a/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
+++ b/home/vue_app/src/components/featured-datasets-carousel/FeaturedDatasetsCarousel.vue
@@ -36,6 +36,7 @@
               v-for="(elem, index) in featured"
               v-bind:key="index"
               :class="{active: index === current}"
+              @click="current = index"
             ></li>
           </ul>
         </div>
@@ -110,13 +111,15 @@ export default {
     height: 100%;
 
     li {
+      cursor: pointer;
       padding: 0;
       display: inline-block;
       margin: 0 0.3em;
       min-width: 2em;
       border-bottom: 5px solid #909399;
 
-      &.active {
+      &.active,
+      &:hover {
         border-bottom: 5px solid #24245b;
       }
     }


### PR DESCRIPTION
# Description

The purpose of this PR is to allow user to use ticks to navigate carousel.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Go to Overview page
- Use ticks on the bottom of the carousel to navigate

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
