### PR TITLE
Wire up homepage search #1a4qry

### DIFF
--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -30,6 +30,7 @@
         <el-col :xs="22" :sm="22" :md="12" :lg="8">
           <search-controls
             :search-on-load="true"
+            submit-text="Go"
             @query="onSearchQuery"
           />
         </el-col>

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -63,6 +63,7 @@
                 fixed
                 prop="name"
                 label="Name"
+                min-width="300"
               />
               <el-table-column
                 prop="fileType"
@@ -76,15 +77,32 @@
                 :formatter="formatStorage"
               />
               <el-table-column
+                align="right"
                 fixed="right"
-                label="Operations"
-                min-width="132"
-                width="132"
+                label="Operation"
+                min-width="100"
+                width="100"
               >
                 <template slot-scope="scope">
-                  <bf-button @click="requestDownloadFile(scope)" >
-                    Download
-                  </bf-button>
+                  <el-dropdown
+                    trigger="click"
+                    @command="onCommandClick"
+                  >
+                    <el-button
+                      icon="el-icon-more"
+                      size="small"
+                    />
+                    <el-dropdown-menu slot="dropdown">
+                      <el-dropdown-item
+                        :command="{
+                          type: 'requestDownloadFile',
+                          scope
+                        }"
+                      >
+                        Download
+                      </el-dropdown-item>
+                    </el-dropdown-menu>
+                  </el-dropdown>
                 </template>
               </el-table-column>
             </el-table>
@@ -110,8 +128,8 @@ import {
   last,
   defaultTo,
   split,
-  path,
-  pathOr
+  pathOr,
+  propOr
 } from 'ramda'
 import Grid from "../grid/Grid.vue";
 import SearchControls from "../search-controls/SearchControls.vue";
@@ -167,6 +185,16 @@ export default {
     onSearchQuery: function(selectedType, terms) {
       this.page = 1
       this.fetchResults(selectedType, terms)
+    },
+
+    onCommandClick: function(evt) {
+      const scope = propOr({}, 'scope', evt)
+      const type = propOr({}, 'type', evt)
+      const handler = this[type]
+
+      if (typeof handler === 'function') {
+        handler(scope)
+      }
     },
 
     selectPage(index) {

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -109,7 +109,11 @@
           </div>
         </el-col>
       </el-row>
-      <el-row type="flex" justify="center">
+      <el-row
+        v-if="totalCount > 0"
+        type="flex"
+        justify="center"
+      >
         <el-col :xs="22" :sm="22" :md="12" :lg="8">
           <pagination
             :selected="page"

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -28,7 +28,10 @@
     <div class="search section">
       <el-row type="flex" justify="center">
         <el-col :xs="22" :sm="22" :md="12" :lg="8">
-          <search-controls @query="onSearchQuery" />
+          <search-controls
+            :search-on-load="true"
+            @query="onSearchQuery"
+          />
         </el-col>
       </el-row>
     </div>
@@ -106,6 +109,7 @@ import {
   last,
   defaultTo,
   split,
+  path,
   pathOr
 } from 'ramda'
 import Grid from "../grid/Grid.vue";
@@ -140,10 +144,6 @@ export default {
       searchType: '',
       searchTerms: ''
     };
-  },
-
-  mounted: function() {
-    this.fetchResults('datasets', '')
   },
 
   methods: {

--- a/dat_core/vue_app/src/components/search-controls/SearchControls.vue
+++ b/dat_core/vue_app/src/components/search-controls/SearchControls.vue
@@ -28,7 +28,18 @@
 </template>
 
 <script>
+import {
+  pathOr
+} from 'ramda'
+
 export default {
+  props: {
+    searchOnLoad: {
+      type: Boolean,
+      default: false
+    }
+  },
+
   data() {
     return {
       selectedType: "datasets",
@@ -46,7 +57,25 @@ export default {
       ]
     };
   },
+
+  mounted: function() {
+    if (this.searchOnLoad) {
+      this.setSearchOnLoad()
+    }
+  },
+
   methods: {
+    /**
+     * Set search and execute search
+     */
+    setSearchOnLoad: function() {
+      const terms = pathOr('', ['query', 'searchTerms'], this.$route)
+      const type = pathOr('datasets', ['query', 'searchType'], this.$route)
+      this.selectedType = type
+      this.terms = terms
+      this.submit()
+    },
+
     submit() {
       this.$emit('query', this.selectedType, this.terms);
     }

--- a/dat_core/vue_app/src/components/search-controls/SearchControls.vue
+++ b/dat_core/vue_app/src/components/search-controls/SearchControls.vue
@@ -1,29 +1,36 @@
 <template>
   <div class="controls">
-    <el-row class="control-row" justify="center" type="flex" gutter="5">
-      <el-col :xs="8" :sm="6">
-        <div class="control">
-          <el-select
-            v-model="selectedType"
-            size="large"
-            style="width: 100%; height: 100%; margin: 0; padding: 0; border-radius: 0"
-            placeholder="Select"
-          >
-            <el-option v-for="type in types" :key="type.key" :value="type.key" :label="type.label" />
-          </el-select>
-        </div>
-      </el-col>
-      <el-col :xs="16" :sm="18">
-        <div class="control">
-          <el-input placeholder="Start typing..." suffix-icon="el-icon-search" v-model="terms"></el-input>
-        </div>
-      </el-col>
-      <el-col :xs="3" :sm="5">
-        <div class="search-button">
-          <el-button type="primary" class="view-search-results" @click.native="submit">View Results</el-button>
-        </div>
-      </el-col>
-    </el-row>
+    <div class="control control-search-type">
+      <el-select
+        v-model="selectedType"
+        size="large"
+        style="width: 100%; height: 100%; margin: 0; padding: 0; border-radius: 0"
+        placeholder="Select"
+      >
+        <el-option
+          v-for="type in types"
+          :key="type.key"
+          :value="type.key"
+          :label="type.label"
+        />
+      </el-select>
+    </div>
+    <div class="control control-search-input">
+      <el-input
+        v-model="terms"
+        placeholder="Start typing..."
+        suffix-icon="el-icon-search"
+      />
+    </div>
+    <div class="search-button">
+      <el-button
+        type="primary"
+        class="view-search-results"
+        @click.native="submit"
+      >
+        {{ submitText }}
+      </el-button>
+    </div>
   </div>
 </template>
 
@@ -37,6 +44,10 @@ export default {
     searchOnLoad: {
       type: Boolean,
       default: false
+    },
+    submitText: {
+      type: String,
+      default: 'View Results'
     }
   },
 
@@ -85,65 +96,36 @@ export default {
 
 <style lang="scss" scoped>
 .controls {
-  padding-top: 1em;
-  min-height: 4em;
+  align-items: center;
+  display: flex;
+}
 
-  .control-row {
-    align-items: baseline;
-  }
+.control {
+  display: inline-block;
+}
 
-  .control {
-    display: inline-block;
-    height: 100%;
-    width: 100%;
-    font-size: 2em;
+.search-control {
+  border: 0;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 100%;
+}
 
-    .search-type-selector {
-      padding: 0.5em;
-      border: 0;
-      color: #8300bf;
-      border-radius: 0;
-      background: none;
-      -webkit-appearance: none;
-      width: 100%;
-      height: 100%;
-
-      > input {
-        border-radius: 0 !important;
-        border: 0 !important;
-        background: none;
-      }
-    }
-
-    .search-input {
-      background: none;
-      border: 0;
-      padding: 0.5em;
-      color: #8300bf;
-      -webkit-appearance: none;
-      width: 100%;
-      height: 100%;
-
-      > input {
-        border-radius: 0 !important;
-        border: 0 !important;
-        background: none;
-      }
-
-      ::placeholder {
-        color: #8300bf;
-        opacity: 1;
-      }
-    }
-  }
+.control-search-type {
+  margin-right: 8px;
+  width: 115px;
+}
+.control-search-input {
+  flex: 1;
+  margin-right: 16px;
 }
 
 .search-button {
 
   .view-search-results {
     background: #24245b;
-    text: #fff;
     border: 0;
+    height: 40px;
   }
 }
 </style>

--- a/dat_core/vue_app/src/main.js
+++ b/dat_core/vue_app/src/main.js
@@ -32,7 +32,11 @@ const router = new VueRouter({
     {
       path: '/',
       name: 'Browse',
-      component: SparcBrowse
+      component: SparcBrowse,
+      query: {
+        searchType: '',
+        searchTerms: ''
+      }
     },
     {
       path: '/datasets/:datasetId',

--- a/home/vue_app/src/components/landing-page/LandingPage.vue
+++ b/home/vue_app/src/components/landing-page/LandingPage.vue
@@ -192,7 +192,11 @@ export default {
      * @param {String} terms
      */
     onSearchQuery: function(selectedType, terms) {
-      window.location.href = `/browse/#/?searchType=${selectedType}&searchTerms=${terms}`
+      const url = terms === null
+        ? `/browse/#/?searchType=${selectedType}`
+        : `/browse/#/?searchType=${selectedType}&searchTerms=${terms}`
+
+      window.location.href = url
     }
   }
 };

--- a/home/vue_app/src/components/landing-page/LandingPage.vue
+++ b/home/vue_app/src/components/landing-page/LandingPage.vue
@@ -88,48 +88,7 @@
       </el-row>
       <el-row type="flex" justify="center">
         <el-col :xs="22" :sm="22" :md="12" :lg="8">
-          <div class="controls">
-            <el-row justify="center" type="flex" gutter="5">
-              <el-col :xs="8" :sm="6">
-                <div class="control">
-                  <el-select
-                    v-model="value2"
-                    multiple
-                    collapse-tags
-                    size="large"
-                    style="width: 100%; height: 100%; margin: 0; padding: 0; border-radius: 0"
-                    placeholder="Select"
-                  >
-                    <el-option key="datasets" label="Datasets" value="datasets"></el-option>
-                    <el-option key="files" label="Files" value="files"></el-option>
-                  </el-select>
-                </div>
-              </el-col>
-              <el-col :xs="16" :sm="18">
-                <div class="control">
-                  <el-autocomplete
-                    v-model="state"
-                    size="large"
-                    :fetch-suggestions="querySearch"
-                    placeholder="Start typing..."
-                    style="width: 100%; height: 100%; border-radius: 0; padding: 0; margin: 0;"
-                    @select="handleSelect"
-                  >
-                    <i class="el-icon-search el-input__icon" slot="suffix" @click="handleIconClick"></i>
-                    <template slot-scope="{ item }">
-                      <div class="value">{{ item.value }}</div>
-                      <span class="link">{{ item.link }}</span>
-                    </template>
-                  </el-autocomplete>
-                </div>
-              </el-col>
-            </el-row>
-            <el-row>
-              <div class="search-button">
-                <el-button type="primary" class="view-search-results">View Results</el-button>
-              </div>
-            </el-row>
-          </div>
+          <search-controls @query="onSearchQuery" />
         </el-col>
       </el-row>
     </div>
@@ -153,6 +112,7 @@ import dataCore from "../../assets/images/data-core.png";
 import datasetAbstractImage from "../../assets/images/dataset-abstract-image.png";
 import SparcFooter from "../../../../../shared/vue_app/src/components/footer/Footer.vue";
 import FeaturedDatasets from "../featured-datasets-carousel/FeaturedDatasetsCarousel.vue";
+import SearchControls from "../../../../../dat_core/vue_app/src/components/search-controls/SearchControls.vue";
 
 const cores = [
   {
@@ -184,7 +144,8 @@ const cores = [
 export default {
   name: "landing-page",
   components: {
-    FeaturedDatasets
+    FeaturedDatasets,
+    SearchControls
   },
 
   data: () => ({
@@ -226,10 +187,12 @@ export default {
     },
 
     /**
-     * @TODO temp function
+     * Navigate to the browse page with search
+     * @param {String} selectedType
+     * @param {String} terms
      */
-    handleIconClick: function() {
-
+    onSearchQuery: function(selectedType, terms) {
+      window.location.href = `/browse/#/?searchType=${selectedType}&searchTerms=${terms}`
     }
   }
 };


### PR DESCRIPTION
# Description

The purpose of this PR is to wire up the search component on the homepage. A side effect of this feature is the ability to link directly to search results on the browse page. In addition, I changed some of the styles on the search results table.

![127 0 0 1_5000_browse_(Laptop with HiDPI screen) (3)](https://user-images.githubusercontent.com/1493195/61470971-f46ff800-a94f-11e9-80bd-2af9cffdbd51.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

## Homepage search
- Go to the Homepage and scroll down to the "Search the portal" section
- Enter something and click on "View Results"
- You should be taken to the Browse page with that search executed. The results should be shown, and the search controls on this page should reflect the search.
- Go back to the Homepage and scroll down to the "Search the portal" section
- Select "Files" from the dropdown, type in `mat` in the input, and click on "View Results"
- You should be taken to the Browse page with that search executed. The results should be shown, and the search controls on this page should reflect the search.
- Go back to the homepage
- Navigate to the Browse page using the main navigation
- Search should show datasets
- Search for files
- Search should function properly


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
