### PR TITLE
Add requester pays param when generated presigned URL

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -76,8 +76,11 @@ def create_presigned_url(expiration=3600):
     bucket_name = 'blackfynn-discover-use1'
     key = request.args.get('key')
     response = s3.generate_presigned_url('get_object',
-                                                    Params={'Bucket': bucket_name,
-                                                            'Key': key},
+                                                    Params={
+                                                        'Bucket': bucket_name,
+                                                        'Key': key,
+                                                        'RequestPayer': 'requester'
+                                                    },
                                                     ExpiresIn=expiration)
 
     return response


### PR DESCRIPTION
# Description

The purpose of this PR is to fix downloading files by adding a requester pays param when generated presigned URL.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to Browse page
- Search for files
- Click on the menu button on the right side of a file's row
- Click download
- File should have downloaded. You can check the request of the file and verify that `x-amz-request-payer=requester` has been added to the URL.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
