### PR TITLE
Fix Tab Names and Remove Footer Links

### DIFF
--- a/dat_core/vue_app/public/index.html
+++ b/dat_core/vue_app/public/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
 <link rel="icon" href="favicon.ico">
-<title>SPARC Portal · Dat Core</title>
+<title>SPARC Portal</title>
 {% endblock %}
 {% block app %}
 <noscript>

--- a/shared/vue_app/src/components/footer/Footer.vue
+++ b/shared/vue_app/src/components/footer/Footer.vue
@@ -27,7 +27,7 @@
                                 <a href="https://nih.gov">Visit the NIH site ></a>
                             </div>
                         </el-col>
-                        <el-col :md="16">
+                        <!-- <el-col :md="16">
                             <el-row type="flex" class="link-sections">
                                 <el-col :key="section.title" :sm="12" :lg="8" class="link-section" v-for="section in footerLinks">
                                     <p class="link-header">{{ section.title }}</p>
@@ -38,7 +38,7 @@
                                     </ul>
                                 </el-col>
                             </el-row>
-                        </el-col>
+                        </el-col> -->
                     </el-row>
                 </div>
             </el-col>

--- a/sim_core/vue_app/public/index.html
+++ b/sim_core/vue_app/public/index.html
@@ -4,7 +4,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
 <link rel="icon" href="favicon.ico" />
 <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css" />
-<title>SPARC Portal · Sim Core</title>
+<title>SPARC Portal</title>
 {% endblock %}
 {% block app %}
 <noscript>


### PR DESCRIPTION
# Description

The purpose of this PR is to change all the tab names in Chrome to `SPARC Portal` and to remove the unused links in the footer for now.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to each nav link the app. All the tabs in the browser should say `SPARC Portal` for each page.
2. The footer should no longer contain the links that were there before.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
