### PR TITLE
Fix where FilesTable was pulling files from version 1 of dataset

### DIFF
--- a/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
+++ b/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
@@ -32,7 +32,7 @@
     <el-row type="flex" justify="center">
       <el-col :xs="22" :sm="22" :md="22" :lg="18" :xl="16">
         <h2>Files</h2>
-        <files-table />
+        <files-table :dataset-details="datasetDetails" />
       </el-col>
     </el-row>
 

--- a/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
+++ b/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
@@ -157,6 +157,15 @@
       FormatStorage
     ],
 
+    props: {
+      datasetDetails: {
+        type: Object,
+        default: function() {
+          return {}
+        }
+      }
+    },
+
     data: function() {
       return {
         path: '',


### PR DESCRIPTION
# Description

The purpose of this PR is to add a fix where FilesTable was pulling files from version 1 of dataset.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open a dataset that has more than one version
- In the network tab, the `/files/browse` endpoint should be looking at the most recent version.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas