### PR TITLE
Enable Microsoft Office Viewers on Portal #1y9jkc[In Review]

### DIFF
--- a/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
+++ b/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
@@ -126,6 +126,15 @@
                 >
                   Download
                 </el-dropdown-item>
+              <el-dropdown-item
+                v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'"
+                :command="{
+                  type: 'openFile',
+                  scope
+                }"
+              >
+                Open File
+              </el-dropdown-item>
               </el-dropdown-menu>
             </el-dropdown>
           </template>
@@ -291,6 +300,34 @@
           }
         )
       },
+
+    /**
+      * Opens a file in a new tab
+      * This is currently for MS Word files only
+      * @param {Object} scope
+    */
+    openFile: function(scope) {
+      const filePath = compose(
+        last,
+        defaultTo([]),
+        split('s3://blackfynn-discover-use1/'),
+        pathOr('', ['row', 'uri']),
+      )(scope)
+
+      const fileName = pathOr('', ['row', 'name'], scope)
+
+      const requestUrl = `/api/download?key=${filePath}`
+
+      this.$http.get(requestUrl).then(
+        response => {
+          const url = response.data
+          const encodedUrl = encodeURIComponent(url)
+          const finalURL = `https://view.officeapps.live.com/op/view.aspx?src=${encodedUrl}`
+          window.open(finalURL, '_blank')
+        }
+      )
+
+    },
 
       /**
        * Create an `a` tag to trigger downloading file

--- a/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
+++ b/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
@@ -303,7 +303,7 @@
 
     /**
       * Opens a file in a new tab
-      * This is currently for MS Word files only
+      * This is currently for MS Word, MS Excel, and Powerpoint files only
       * @param {Object} scope
     */
     openFile: function(scope) {

--- a/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
+++ b/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
@@ -133,7 +133,7 @@
                   scope
                 }"
               >
-                Open File
+                Open
               </el-dropdown-item>
               </el-dropdown-menu>
             </el-dropdown>

--- a/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
+++ b/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
@@ -72,7 +72,12 @@
                   v-else
                   class="file-icon el-icon-document"
                 />
-                <span class="file-name">{{ scope.row.name }}</span>
+                  <div v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'">
+                    <a href="#" @click.prevent="openFile(scope)">  {{ scope.row.name }} </a>
+                  </div>
+                  <div v-else>
+                    {{ scope.row.name }}
+                  </div>
               </template>
             </div>
           </template>

--- a/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
+++ b/dat_core/vue_app/src/components/FilesTable/FilesTable.vue
@@ -72,7 +72,7 @@
                   v-else
                   class="file-icon el-icon-document"
                 />
-                  <div v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'">
+                  <div v-if="isMicrosoftFileType(scope)">
                     <a href="#" @click.prevent="openFile(scope)">  {{ scope.row.name }} </a>
                   </div>
                   <div v-else>
@@ -132,7 +132,7 @@
                   Download
                 </el-dropdown-item>
               <el-dropdown-item
-                v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'"
+                v-if="isMicrosoftFileType(scope)"
                 :command="{
                   type: 'openFile',
                   scope
@@ -198,6 +198,7 @@
         )(this.path)
       },
 
+
       /**
        * Compute endpoint URL to get dataset's files
        * @returns {String}
@@ -227,6 +228,14 @@
     },
 
     methods: {
+
+      /**
+       * Checks if file is MS Word, MS Excel, or MS Powerpoint
+       * @param {Object} scope
+       */
+      isMicrosoftFileType: function(scope) {
+        return scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'
+      },
       /**
        * Get contents of directory
        */

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -294,6 +294,7 @@ export default {
       const fileName = pathOr('', ['row', 'name'], scope)
 
       const requestUrl = `/api/download?key=${filePath}`
+
       this.$http.get(requestUrl).then(
         response => {
           this.downloadFile(fileName, response.data)
@@ -307,7 +308,26 @@ export default {
      * @param {Object} scope
      */
     openFile: function(scope) {
-      
+      const filePath = compose(
+        last,
+        defaultTo([]),
+        split('s3://blackfynn-discover-use1/'),
+        pathOr('', ['row', 'uri']),
+      )(scope)
+
+      const fileName = pathOr('', ['row', 'name'], scope)
+
+      const requestUrl = `/api/download?key=${filePath}`
+
+      this.$http.get(requestUrl).then(
+        response => {
+          const url = response.data
+          const encodedUrl = encodeURIComponent(url)
+          const finalURL = `https://view.officeapps.live.com/op/view.aspx?src=${encodedUrl}`
+          window.open(finalURL, '_blank')
+        }
+      )
+
     },
 
     /**

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -58,10 +58,18 @@
             <el-table :data="results">
               <el-table-column
                 fixed
-                prop="name"
                 label="Name"
                 min-width="300"
-              />
+              >
+                <template slot-scope="scope">
+                  <div v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'">
+                    <a href="#" @click.prevent="openFile(scope)">  {{ scope.row.name }} </a>
+                  </div>
+                  <div v-else>
+                    {{ scope.row.name }}
+                  </div>
+                </template>
+              </el-table-column>
               <el-table-column
                 prop="fileType"
                 label="File type"

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -105,7 +105,7 @@
                           scope
                         }"
                       >
-                        Open File
+                        Open
                       </el-dropdown-item>
                     </el-dropdown-menu>
                   </el-dropdown>

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -304,7 +304,7 @@ export default {
 
     /**
      * Opens a file in a new tab
-     * This is currently for MS Word files only
+     * This is currently for MS Word, MS Excel, and Powerpoint files only
      * @param {Object} scope
      */
     openFile: function(scope) {

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -62,7 +62,7 @@
                 min-width="300"
               >
                 <template slot-scope="scope">
-                  <div v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'">
+                  <div v-if="isMicrosoftFileType(scope)">
                     <a href="#" @click.prevent="openFile(scope)">  {{ scope.row.name }} </a>
                   </div>
                   <div v-else>
@@ -107,7 +107,7 @@
                         Download
                       </el-dropdown-item>
                       <el-dropdown-item
-                        v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'"
+                        v-if="isMicrosoftFileType(scope)"
                         :command="{
                           type: 'openFile',
                           scope
@@ -200,6 +200,14 @@ export default {
   },
 
   methods: {
+
+    /**
+       * Checks if file is MS Word, MS Excel, or MS Powerpoint
+       * @param {Object} scope
+       */
+      isMicrosoftFileType: function(scope) {
+        return scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'
+      },
     /**
      * Format storage column
      * @param {Object} row

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -98,6 +98,15 @@
                       >
                         Download
                       </el-dropdown-item>
+                      <el-dropdown-item
+                        v-if="scope.row.fileType === 'MSWord'"
+                        :command="{
+                          type: 'openFile',
+                          scope
+                        }"
+                      >
+                        Open File
+                      </el-dropdown-item>
                     </el-dropdown-menu>
                   </el-dropdown>
                 </template>
@@ -290,6 +299,15 @@ export default {
           this.downloadFile(fileName, response.data)
         }
       )
+    },
+
+    /**
+     * Opens a file in a new tab
+     * This is currently for MS Word files only
+     * @param {Object} scope
+     */
+    openFile: function(scope) {
+      
     },
 
     /**

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -99,7 +99,7 @@
                         Download
                       </el-dropdown-item>
                       <el-dropdown-item
-                        v-if="scope.row.fileType === 'MSWord'"
+                        v-if="scope.row.fileType === 'MSWord' || scope.row.fileType === 'MSExcel' || scope.row.fileType === 'PowerPoint'"
                         :command="{
                           type: 'openFile',
                           scope


### PR DESCRIPTION
# Description

The purpose of this PR is to enable Microsoft Office Viewers for files that are of type `MSWord`, `MSExcel` and `PowerPoint` on the `Browse Data` page and the files directory for individual datasets.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to `Browse Data` on the navigation bar and select `Files` from the dropdown.
2. Look for a `MSWord`, `PowerPoint`, or `MSExcel` file. Click on the overflow menu and click on `Open`
3. The file should open in a new tab in the appropriate viewer.
4. Click on the file name in the table. The file should open in the same manner.

Repeat steps 1-4 for files in an individual dataset. The behavior should be the same.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
