### PR TITLE
Overview Block Carousel #1rb8km

### DIFF
--- a/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
+++ b/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
@@ -1,55 +1,78 @@
 <template>
-     <div class='carousel-view'>
-    <transition-group
-      class='carousel'
-      tag="div">
-      <div
-        v-for="slide in slides"
-        class='slide'
-        :key="slide.id">
-        <h4> {{ slide.title }} </h4>
+  <div class="carousel-view">
+    <div class="carousel-controls">
+      <div class="options">
+        <span class="option">
+          <a :class="{ active: activeTextBlock === 'goal' }" href="#" @click.prevent="next">Goal</a>
+        </span>
+        <span>•</span>
+        <span class="option">
+          <a
+            :class="{ active: activeTextBlock === 'current' }"
+            href="#"
+            @click.prevent="next"
+          >Current</a>
+        </span>
+        <span>•</span>
+        <span class="option">
+          <a :class="{ active: activeTextBlock === 'future' }" href="#" @click.prevent="next">Future</a>
+        </span>
+      </div>
+    </div>
+    <transition-group class="carousel" tag="div">
+      <div v-for="slide in slides" class="slide" :key="slide.id">
+        <h4>{{ slide.title }}</h4>
       </div>
     </transition-group>
-    <div class='carousel-controls'>
-      <button class='carousel-controls__button' @click="previous">prev</button>
-      <button class='carousel-controls__button' @click="next">next</button>
-    </div>
   </div>
 </template>
 
 <script>
-    export default {
-        name: 'OverviewCarousel',
-        data() {
-            return {
-                slides: [
-                {
-                    title: 'Catalyze the development of next-generation bioelectronic medicines by providing access to high-value datasets, maps, and predictive simuatations',
-                    id: 1
-                },
-                {
-                    title: 'Launched in July 2019, the SPARC Portal is an open-source web application that provides access to a growing collection of interactive autonomic neuroscience resources',
-                    id: 2
-                },
-                {
-                    title: 'The SPARC Portal will enable users to run advanced analytics and computational studies to predict the effects of neuromodulation on organ function.',
-                    id: 3
-                }
-            ]
-            }
+export default {
+  name: "OverviewCarousel",
+  data() {
+    return {
+      slides: [
+        {
+          title:
+            "Catalyze the development of next-generation bioelectronic medicines by providing access to high-value datasets, maps, and predictive simuatations",
+          id: 1
         },
+        {
+          title:
+            "Launched in July 2019, the SPARC Portal is an open-source web application that provides access to a growing collection of interactive autonomic neuroscience resources",
+          id: 2
+        },
+        {
+          title:
+            "The SPARC Portal will enable users to run advanced analytics and computational studies to predict the effects of neuromodulation on organ function.",
+          id: 3
+        }
+      ],
+      activeTextBlock: "goal"
+    };
+  },
 
-        methods: {
-             next () {
-      const first = this.slides.shift()
-      this.slides = this.slides.concat(first)
+  created() {
+    setInterval(this.next, 5000);
+  },
+
+  methods: {
+    next: function () {
+      const first = this.slides.shift();
+      if (first.id === 2) {
+        this.activeTextBlock = "current";
+      } else {
+        this.activeTextBlock = "future";
+      }
+      this.slides = this.slides.concat(first);
     },
-    previous () {
-      const last = this.slides.pop()
-      this.slides = [last].concat(this.slides)
+    previous: function () {
+      const last = this.slides.pop();
+      this.slides = [last].concat(this.slides);
     }
-        },
-    }
+  }
+};
 </script>
 
 <style lang="scss" scoped>
@@ -63,20 +86,33 @@
   justify-content: center;
   align-items: center;
   overflow: hidden;
-  width: 24em;
 }
 .slide {
-  flex: 0 0 20em;
+  flex: 0 0 50em;
   margin: 1em;
   display: flex;
   justify-content: center;
   align-items: center;
   transition: transform 0.3s ease-in-out;
+  font-weight: normal;
 }
 .slide:first-of-type {
   opacity: 0;
 }
 .slide:last-of-type {
   opacity: 0;
+}
+
+.option {
+  padding: 0 0.5em;
+
+  a {
+    text-decoration: none;
+    color: #f9f2fc;
+
+    &.active {
+      color: #c200fd;
+    }
+  }
 }
 </style>

--- a/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
+++ b/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
@@ -1,0 +1,82 @@
+<template>
+     <div class='carousel-view'>
+    <transition-group
+      class='carousel'
+      tag="div">
+      <div
+        v-for="slide in slides"
+        class='slide'
+        :key="slide.id">
+        <h4> {{ slide.title }} </h4>
+      </div>
+    </transition-group>
+    <div class='carousel-controls'>
+      <button class='carousel-controls__button' @click="previous">prev</button>
+      <button class='carousel-controls__button' @click="next">next</button>
+    </div>
+  </div>
+</template>
+
+<script>
+    export default {
+        name: 'OverviewCarousel',
+        data() {
+            return {
+                slides: [
+                {
+                    title: 'Catalyze the development of next-generation bioelectronic medicines by providing access to high-value datasets, maps, and predictive simuatations',
+                    id: 1
+                },
+                {
+                    title: 'Launched in July 2019, the SPARC Portal is an open-source web application that provides access to a growing collection of interactive autonomic neuroscience resources',
+                    id: 2
+                },
+                {
+                    title: 'The SPARC Portal will enable users to run advanced analytics and computational studies to predict the effects of neuromodulation on organ function.',
+                    id: 3
+                }
+            ]
+            }
+        },
+
+        methods: {
+             next () {
+      const first = this.slides.shift()
+      this.slides = this.slides.concat(first)
+    },
+    previous () {
+      const last = this.slides.pop()
+      this.slides = [last].concat(this.slides)
+    }
+        },
+    }
+</script>
+
+<style lang="scss" scoped>
+.carousel-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.carousel {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  width: 24em;
+}
+.slide {
+  flex: 0 0 20em;
+  margin: 1em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: transform 0.3s ease-in-out;
+}
+.slide:first-of-type {
+  opacity: 0;
+}
+.slide:last-of-type {
+  opacity: 0;
+}
+</style>

--- a/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
+++ b/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
@@ -53,18 +53,21 @@ export default {
     };
   },
 
-  created() {
+  mounted() {
     setInterval(this.next, 5000);
   },
 
   methods: {
     next: function () {
       const first = this.slides.shift();
-      if (first.id === 2) {
-        this.activeTextBlock = "current";
-      } else {
-        this.activeTextBlock = "future";
-      }
+      console.log ("first one ", first)
+      // if (first.id === 1) {
+      //   this.activeTextBlock = "goal"
+      // } else if (first.id === 2) {
+      //   this.activeTextBlock = "current";
+      // } else {
+      //   this.activeTextBlock = "future";
+      // }
       this.slides = this.slides.concat(first);
     },
     previous: function () {

--- a/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
+++ b/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
@@ -34,45 +34,47 @@ export default {
     return {
       slides: [
         {
+          title: "The SPARC Portal will enable users to run advanced analytics and computational studies to predict the effects of neuromodulation on organ function.",
+          id: 3,
+          heading: 'future'
+        },
+        {
           title:
             "Catalyze the development of next-generation bioelectronic medicines by providing access to high-value datasets, maps, and predictive simuatations",
-          id: 1
+          id: 1,
+          heading: 'goal'
         },
         {
           title:
             "Launched in July 2019, the SPARC Portal is an open-source web application that provides access to a growing collection of interactive autonomic neuroscience resources",
-          id: 2
-        },
-        {
-          title:
-            "The SPARC Portal will enable users to run advanced analytics and computational studies to predict the effects of neuromodulation on organ function.",
-          id: 3
+          id: 2,
+          heading: 'current'
         }
       ],
-      activeTextBlock: "goal"
+      activeTextBlock: 'goal'
     };
   },
 
-  mounted() {
+  created() {
     setInterval(this.next, 5000);
   },
 
+
   methods: {
+    /**
+     * Function to iterate to the next slide and change the
+     * navigation ticker
+     */
     next: function () {
       const first = this.slides.shift();
-      console.log ("first one ", first)
-      // if (first.id === 1) {
-      //   this.activeTextBlock = "goal"
-      // } else if (first.id === 2) {
-      //   this.activeTextBlock = "current";
-      // } else {
-      //   this.activeTextBlock = "future";
-      // }
+      if (this.activeTextBlock === 'goal'){
+        this.activeTextBlock = 'current'
+      } else if (this.activeTextBlock === 'current') {
+        this.activeTextBlock = 'future'
+      } else {
+        this.activeTextBlock = 'goal'
+      }
       this.slides = this.slides.concat(first);
-    },
-    previous: function () {
-      const last = this.slides.pop();
-      this.slides = [last].concat(this.slides);
     }
   }
 };

--- a/home/vue_app/src/components/landing-page/LandingPage.vue
+++ b/home/vue_app/src/components/landing-page/LandingPage.vue
@@ -40,24 +40,6 @@
       </div>
       <div class="section content">
         <el-row type="flex" justify="center">
-          <!-- <el-col :xs="22" :sm="22" :md="14" :lg="14">
-            <div class="options">
-              <span class="option">
-                <a :class="{ active: activeTextBlock === 'goal' }" href="#" @click.prevent="toggleText('goal')">Goal</a>
-              </span>
-              <span>•</span>
-              <span class="option">
-                <a :class="{ active: activeTextBlock === 'current' }" href="#" @click.prevent="toggleText('current')">Current</a>
-              </span>
-              <span>•</span>
-              <span class="option">
-                <a :class="{ active: activeTextBlock === 'future' }" href="#" @click.prevent="toggleText('future')">Future</a>
-              </span>
-            </div>
-            <p>
-              {{ activeText }}
-            </p>
-          </el-col> -->
           <overview-carousel />
         </el-row>
       </div>

--- a/home/vue_app/src/components/landing-page/LandingPage.vue
+++ b/home/vue_app/src/components/landing-page/LandingPage.vue
@@ -40,7 +40,7 @@
       </div>
       <div class="section content">
         <el-row type="flex" justify="center">
-          <el-col :xs="22" :sm="22" :md="14" :lg="14">
+          <!-- <el-col :xs="22" :sm="22" :md="14" :lg="14">
             <div class="options">
               <span class="option">
                 <a :class="{ active: activeTextBlock === 'goal' }" href="#" @click.prevent="toggleText('goal')">Goal</a>
@@ -57,7 +57,8 @@
             <p>
               {{ activeText }}
             </p>
-          </el-col>
+          </el-col> -->
+          <overview-carousel />
         </el-row>
       </div>
     </div>
@@ -113,6 +114,7 @@ import dataCore from "../../assets/images/datcore-card-image.svg";
 import datasetAbstractImage from "../../assets/images/dataset-abstract-image.png";
 import SparcFooter from "../../../../../shared/vue_app/src/components/footer/Footer.vue";
 import FeaturedDatasets from "../featured-datasets-carousel/FeaturedDatasetsCarousel.vue";
+import OverviewCarousel from '../OverviewCarousel/OverviewCarousel.vue'
 import SearchControls from "../../../../../dat_core/vue_app/src/components/search-controls/SearchControls.vue";
 
 const cores = [
@@ -143,7 +145,8 @@ export default {
   name: "landing-page",
   components: {
     FeaturedDatasets,
-    SearchControls
+    SearchControls,
+    OverviewCarousel
   },
 
   data: () => ({


### PR DESCRIPTION
# Description

The purpose of this PR is to change the `Goal - Current - Future` block text on the overview page to a rotating carousel

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Navigate to the homepage and scroll down to the `Goal - Current - Future` block. It should be rotating as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
