### PR TITLE
Fix Active About Link #1rb8pe

### DIFF
--- a/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
+++ b/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
@@ -66,7 +66,7 @@ export default {
      * Start autoplay for slides
      */
     startAutoplay: function () {
-      this.timer = setInterval(this.next, 10000);
+      this.timer = setInterval(this.next, 7000);
     },
 
     /**

--- a/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
+++ b/home/vue_app/src/components/OverviewCarousel/OverviewCarousel.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="carousel-view">
+    <div class="carousel-controls">
+      <div class="options">
+        <span class="option">
+          <a :class="{ active: activeTextBlock === 'Goal' }" href="#" @click.prevent="next">Goal</a>
+        </span>
+        <span>•</span>
+        <span class="option">
+          <a
+            :class="{ active: activeTextBlock === 'Current' }"
+            href="#"
+            @click.prevent="next"
+          >Current</a>
+        </span>
+        <span>•</span>
+        <span class="option">
+          <a :class="{ active: activeTextBlock === 'Future' }" href="#" @click.prevent="next">Future</a>
+        </span>
+      </div>
+    </div>
+  <el-row type="flex" justify="center">
+    <transition-group tag="div">
+      <div v-for="slide in slides" class="slide" :key="slide.id">
+        <h4>{{ slide.title }}</h4>
+      </div>
+    </transition-group>
+    </el-row>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "OverviewCarousel",
+  data() {
+    return {
+      slides: [
+        {
+          title: "The SPARC Portal will enable users to run advanced analytics and computational studies to predict the effects of neuromodulation on organ function.",
+          id: 3,
+          heading: 'Future'
+        },
+        {
+          title:
+            "Catalyze the development of next-generation bioelectronic medicines by providing access to high-value datasets, maps, and predictive simuatations",
+          id: 1,
+          heading: 'Goal'
+        },
+        {
+          title:
+            "Launched in July 2019, the SPARC Portal is an open-source web application that provides access to a growing collection of interactive autonomic neuroscience resources",
+          id: 2,
+          heading: 'Current'
+        }
+      ],
+      activeTextBlock: 'Goal'
+    };
+  },
+
+  created() {
+    setInterval(this.next, 10000);
+  },
+
+
+  methods: {
+    /**
+     * Function to iterate to the next slide and change the
+     * navigation ticker
+     */
+    next: function () {
+      const first = this.slides.shift();
+      if (this.activeTextBlock === 'Goal'){
+        this.activeTextBlock = 'Current'
+      } else if (this.activeTextBlock === 'Current') {
+        this.activeTextBlock = 'Future'
+      } else {
+        this.activeTextBlock = 'Goal'
+      }
+      this.slides = this.slides.concat(first);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.carousel-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.carousel {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+.slide {
+  flex: 0 0 50em;
+  margin: 1em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: visibility 0s, opacity 0s linear;
+  font-weight: normal;
+}
+.slide:first-of-type {
+  opacity: 0;
+}
+.slide:last-of-type {
+  opacity: 0;
+}
+
+.option {
+  padding: 0 0.5em;
+
+  a {
+    text-decoration: none;
+    color: #f9f2fc;
+
+    &.active {
+      color: #c200fd;
+    }
+  }
+}
+</style>

--- a/home/vue_app/src/components/about-page/AboutPage.vue
+++ b/home/vue_app/src/components/about-page/AboutPage.vue
@@ -20,10 +20,7 @@
 
 <script>
     export default {
-        name: 'about-page',
-        components: {
-
-        }
+        name: 'about-page'
     }
 </script>
 

--- a/shared/vue_app/src/components/header/Header.vue
+++ b/shared/vue_app/src/components/header/Header.vue
@@ -31,7 +31,7 @@
                         </div>
                         <ul>
                             <li :key="link.href" v-for="link in links">
-                                <a v-bind:class="{active: link.active}" :href="link.href">{{ link.title }}</a>
+                                <a v-bind:class="{active: link.active}" :href="link.href" @click="changeActiveValue(link.href)">{{ link.title }}</a>
                             </li>
                         </ul>
                     </div>
@@ -47,7 +47,11 @@
     const path = () => window.location.pathname || "";
     const hash = () => window.location.hash || "";
 
-    const pathOrHashContainsString = (query) => (path().indexOf(query) > -1) || (hash().indexOf(query) > -1);
+  //  const pathOrHashContainsString = (query) => (path().indexOf(query) > -1) || (hash().indexOf(query) > -1);
+    const pathOrHashContainsString = function(query) {
+        // console.log("window object ", window)
+        return path().indexOf(query) > -1 || hash().indexOf(query) > -1
+    }
 
     const links = [
         {
@@ -89,7 +93,16 @@
         data: () => ({
             links,
             menuOpen: false
-        })
+        }),
+        methods: {
+            changeActiveValue: function(link) {
+                if (link === '/#/about') {
+                    this.links[0].active = false
+                    this.links[1].active = true
+                }
+                return link
+            }
+        },
     }
 </script>
 

--- a/shared/vue_app/src/components/header/Header.vue
+++ b/shared/vue_app/src/components/header/Header.vue
@@ -47,11 +47,7 @@
     const path = () => window.location.pathname || "";
     const hash = () => window.location.hash || "";
 
-  //  const pathOrHashContainsString = (query) => (path().indexOf(query) > -1) || (hash().indexOf(query) > -1);
-    const pathOrHashContainsString = function(query) {
-        // console.log("window object ", window)
-        return path().indexOf(query) > -1 || hash().indexOf(query) > -1
-    }
+    const pathOrHashContainsString = (query) => (path().indexOf(query) > -1) || (hash().indexOf(query) > -1);
 
     const links = [
         {


### PR DESCRIPTION
# Description

The purpose of this PR is to fix the issue in the `About` link in the navigation bar, where it was not being set as the active link when navigating from `Overview` to `About`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Navigate from `Overview` to `About`. There should be an underline under `About` as expected. Verify that this underline still appears when navigating to `About` from the other pages as well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
