### PR TITLE
Add Protocols.io Link to Datasets

### DIFF
--- a/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
+++ b/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
@@ -326,6 +326,9 @@ export default {
       immediate: true
     },
 
+    /**
+     * Watcher for getSearchRecordsUrl
+     */
     getSearchRecordsUrl : {
       handler: function (val) {
         if (val) {

--- a/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
+++ b/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
@@ -49,14 +49,13 @@
             </el-row>
             <el-row class="mb-16">
               <el-col
-                class="info-publishing-history"
                 :span="24"
               >
+                <h3>
+                  Last Updated
+                </h3>
                 <div class="info-text">
                   {{ lastUpdatedDate }}
-                  <div class="info-text-caps">
-                    Last Updated
-                  </div>
                 </div>
               </el-col>
             </el-row>


### PR DESCRIPTION
# Description

The purpose of this PR is to add the protocols.io links and doi link for each dataset on the dataset details page.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to a dataset on the data portal that has protocols record in its models (such as [this one](http://localhost:5000/browse/#/datasets/22))
2. Scroll to the footer of the page. You should see the Dataset DOI link and Protocol DOIs listed for that dataset.
3. Navigate to a dataset on the data portal that does not have a protocols record in its models (such as [this one](http://localhost:5000/browse/#/datasets/33))
4. Scroll to the footer of the page. You should only see the Dataset DOI link listed for that dataset.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
