### PR TITLE
Add Metadata Table for Datasets #1u8w1p

### DIFF
--- a/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
+++ b/dat_core/vue_app/src/components/DatasetDetails/DatasetDetails.vue
@@ -36,6 +36,13 @@
       </el-col>
     </el-row>
 
+    <el-row type="flex" justify="center">
+      <el-col :xs="22" :sm="22" :md="22" :lg="18" :xl="16">
+        <h2>Metadata</h2>
+        <metadata-table :dataset-details="datasetDetails" />
+      </el-col>
+    </el-row>
+
     <div class="dataset-info">
       <div class="discover-content container-fluid dataset-info-container">
         <el-row type="flex" justify="center">
@@ -159,6 +166,7 @@ import {
 import DatasetHeader from '../DatasetHeader/DatasetHeader.vue'
 import TagList from '../TagList/TagList.vue'
 import FilesTable from '../FilesTable/FilesTable.vue'
+import MetadataTable from '../MetadataTable/MetadataTable.vue'
 
 import Request from '../../mixins/request'
 import DateUtils from '../../mixins/format-date'
@@ -173,6 +181,7 @@ export default {
   components: {
     DatasetHeader,
     FilesTable,
+    MetadataTable,
     TagList
   },
 

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -37,13 +37,26 @@
         />
       </el-table>
     </div>
+    <div class="metadata-table-pagination">
+        <pagination
+            :selected="page"
+            :page-size="limit"
+            :total-count="totalCount"
+            @select-page="selectPage"
+          />
+    </div>
+
     </div>
 </template>
 
 <script>
 import { propOr, head } from 'ramda'
+import Pagination from '../Pagination/Pagination.vue'
     export default {
         name: 'MetadataTable',
+        components: {
+            Pagination,
+        },
         data() {
             return {
                 isLoading: false,
@@ -52,7 +65,11 @@ import { propOr, head } from 'ramda'
                 properties: [],
                 headings: [],
                 defaultModel: '',
-                dropdownSelection: false
+                dropdownSelection: false,
+                limit: 3,
+                offset: 0,
+                totalCount: 0,
+                page: 1
             }
         },
 
@@ -98,10 +115,12 @@ import { propOr, head } from 'ramda'
                     this.dropdownSelection = true
                     this.defaultModel = model
                 }
-                this.axios.get(this.getRecordsUrl)
+                this.offset = (this.page - 1) * this.limit
+                this.axios.get(`${this.getRecordsUrl}&limit=${this.limit}&offset=${this.offset}`)
         .then(response => {
            this.headings = []
            this.properties = []
+           this.totalCount = response.data.totalCount
            this.records = propOr([], 'records', response.data)
            const properties = propOr({}, 'properties', head(this.records))
            // just to get the property names for the table since they're all
@@ -122,6 +141,11 @@ import { propOr, head } from 'ramda'
           this.errorLoading = true
         })
             },
+
+            selectPage: function(index) {
+                this.page = index
+                this.getMetadataRecords()
+            }
         },
     }
 </script>
@@ -132,6 +156,15 @@ import { propOr, head } from 'ramda'
       border: 1px solid rgb(228, 231, 237);
       padding: 16px;
       margin-top: 20px;
-      margin-bottom: 30px;
+      margin-bottom: 10px;
+    }
+
+    .metadata-table-dropdown {
+        margin-top: 8px;
+        margin-bottom: 5px;
+    }
+
+    .metadata-table-pagination {
+        margin-bottom: 10px;
     }
 </style>

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -66,7 +66,7 @@ import Pagination from '../Pagination/Pagination.vue'
                 headings: [],
                 defaultModel: '',
                 dropdownSelection: false,
-                limit: 3,
+                limit: 10,
                 offset: 0,
                 totalCount: 0,
                 page: 1

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -1,0 +1,153 @@
+<template>
+    <div class="metadata-table">
+        <div class="metadata-table-dropdown">
+             <el-select v-model="value" placeholder="Select Model" @change="getMetadataRecords">
+    <el-option
+      v-for="(model, index) in models"
+      :key="`${model}-${index}`"
+      :label="model.modelName"
+      :value="model.modelName">
+    </el-option>
+  </el-select>
+        </div>
+         <div class="metadata-table-content">
+      <div
+        v-if="hasError"
+        class="error-wrap"
+      >
+        <p>Sorry, an error has occurred</p>
+        <el-button
+          type="primary"
+          @click="getMetadataRecords"
+        >
+          Try again
+        </el-button>
+      </div>
+      <el-table
+        v-else
+        :data="properties"
+        :default-sort = "{prop: 'name', order: 'ascending'}"
+        v-loading="isLoading"
+      >
+        <el-table-column
+          v-for="prop in properties"
+          :key="prop.label"
+          :prop="prop.value"
+          :label="prop.label"
+          :formatter="formatColumn"
+        >
+        </el-table-column>
+          <!-- <template
+            v-if="scope.row.type === 'File'"
+            slot-scope="scope"
+          >
+            <el-dropdown
+              trigger="click"
+              @command="onCommandClick"
+            >
+              <el-button
+                icon="el-icon-more"
+                size="small"
+              />
+              <el-dropdown-menu slot="dropdown">
+                <el-dropdown-item
+                  :command="{
+                    type: 'requestDownloadFile',
+                    scope
+                  }"
+                >
+                  Download
+                </el-dropdown-item>
+              </el-dropdown-menu>
+            </el-dropdown>
+          </template> -->
+      </el-table>
+    </div>
+    </div>
+</template>
+
+<script>
+import { propOr, head, find, propEq } from 'ramda'
+    export default {
+        name: 'MetadataTable',
+        data() {
+            return {
+                isLoading: false,
+                models: [],
+                records: [],
+                properties: []
+            }
+        },
+
+        props: {
+            datasetDetails: {
+                type: Object,
+                default: () => {}
+            },
+        },
+
+        computed: {
+            getRecordsUrl: function() {
+                const model = propOr('', 'modelName', head(this.models))
+                const datasetId = propOr('', 'id', this.datasetDetails)
+                return `https://api.blackfynn.io/discover/search/records?datasetId=${datasetId}&model=${model}`
+            }
+        },
+
+        watch: {
+            getRecordsUrl:{
+                handler: function(val) {
+                    if (val) {
+                        this.getMetadataRecords()
+                    }
+                },
+                immediate: true
+            },
+            datasetDetails: {
+                handler: function(val){
+                    if (val) {
+                      this.models = propOr([], 'modelCount', this.datasetDetails)
+                    }
+                },
+                immediate: true
+            }
+        },
+
+        methods: {
+            getMetadataRecords: function() {
+                this.axios.get(this.getRecordsUrl)
+        .then(response => {
+           this.records = propOr([], 'records', response.data)
+           this.records.forEach(record => {
+              const properties = propOr({}, 'properties', record)
+
+
+              for (let key in properties) {
+                  const keyExists = find(propEq('label', key), this.properties)
+                  if (keyExists) {
+                      // find the object with that key and push to the array
+                  }
+                this.properties.push({
+                    label: key,
+                    value: properties[key]
+                })
+              }
+           })
+
+        })
+        .catch(error => {
+          // handle error
+          this.errorLoading = true
+        })
+            },
+
+        formatColumn: function(row) {
+            return row.value
+        }
+        },
+    }
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="metadata-table">
     <div class="metadata-table-dropdown">
-        <el-select v-model="value" placeholder="Select Model" @change="getMetadataRecords">
+        <el-select v-model="value" @change="getMetadataRecords">
             <el-option
             v-for="(model, index) in models"
             :key="`${model}-${index}`"
@@ -34,6 +34,7 @@
           :key="heading"
           :prop="heading"
           :label="heading"
+          min-width="300"
         />
       </el-table>
   </div>
@@ -58,7 +59,7 @@ import Pagination from '../Pagination/Pagination.vue'
     },
     data() {
       return {
-        isLoading: false,
+        isLoading: true,
         models: [],
         records: [],
         properties: [],
@@ -68,7 +69,8 @@ import Pagination from '../Pagination/Pagination.vue'
         limit: 10,
         offset: 0,
         totalCount: 0,
-        page: 1
+        page: 1,
+        value: ''
       }
     },
     props: {
@@ -82,6 +84,7 @@ import Pagination from '../Pagination/Pagination.vue'
       getRecordsUrl: function() {
         if (!this.dropdownSelection) {
           this.defaultModel = propOr('', 'modelName', head(this.models))
+          this.value = this.defaultModel
         }
         const datasetId = propOr('', 'id', this.datasetDetails)
         return `https://api.blackfynn.io/discover/search/records?datasetId=${datasetId}&model=${this.defaultModel}`
@@ -109,7 +112,6 @@ import Pagination from '../Pagination/Pagination.vue'
 
     methods: {
       getMetadataRecords: function(model = '') {
-        this.isLoading = true
         if (model !== '') {
           this.dropdownSelection = true
           this.defaultModel = model

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -111,6 +111,7 @@ import Pagination from '../Pagination/Pagination.vue'
 
         methods: {
             getMetadataRecords: function(model = '') {
+                this.isLoading = true
                 if (model !== '') {
                     this.dropdownSelection = true
                     this.defaultModel = model
@@ -118,6 +119,7 @@ import Pagination from '../Pagination/Pagination.vue'
                 this.offset = (this.page - 1) * this.limit
                 this.axios.get(`${this.getRecordsUrl}&limit=${this.limit}&offset=${this.offset}`)
         .then(response => {
+           this.isLoading = false
            this.headings = []
            this.properties = []
            this.totalCount = response.data.totalCount

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -1,16 +1,16 @@
 <template>
-    <div class="metadata-table">
-        <div class="metadata-table-dropdown">
-             <el-select v-model="value" placeholder="Select Model" @change="getMetadataRecords">
-    <el-option
-      v-for="(model, index) in models"
-      :key="`${model}-${index}`"
-      :label="model.modelName"
-      :value="model.modelName">
-    </el-option>
-  </el-select>
-        </div>
-         <div class="metadata-table-content">
+<div class="metadata-table">
+    <div class="metadata-table-dropdown">
+        <el-select v-model="value" placeholder="Select Model" @change="getMetadataRecords">
+            <el-option
+            v-for="(model, index) in models"
+            :key="`${model}-${index}`"
+            :label="model.modelName"
+            :value="model.modelName">
+            </el-option>
+         </el-select>
+    </div>
+    <div class="metadata-table-content">
       <div
         v-if="hasError"
         class="error-wrap"
@@ -36,88 +36,86 @@
           :label="heading"
         />
       </el-table>
-    </div>
-    <div class="metadata-table-pagination">
-        <pagination
-            :selected="page"
-            :page-size="limit"
-            :total-count="totalCount"
-            @select-page="selectPage"
-          />
-    </div>
-
-    </div>
+  </div>
+  <div class="metadata-table-pagination">
+    <pagination
+        :selected="page"
+        :page-size="limit"
+        :total-count="totalCount"
+        @select-page="selectPage"
+    />
+   </div>
+</div>
 </template>
 
 <script>
 import { propOr, head } from 'ramda'
 import Pagination from '../Pagination/Pagination.vue'
-    export default {
-        name: 'MetadataTable',
-        components: {
-            Pagination,
-        },
-        data() {
-            return {
-                isLoading: false,
-                models: [],
-                records: [],
-                properties: [],
-                headings: [],
-                defaultModel: '',
-                dropdownSelection: false,
-                limit: 10,
-                offset: 0,
-                totalCount: 0,
-                page: 1
-            }
-        },
+  export default {
+    name: 'MetadataTable',
+    components: {
+      Pagination,
+    },
+    data() {
+      return {
+        isLoading: false,
+        models: [],
+        records: [],
+        properties: [],
+        headings: [],
+        defaultModel: '',
+        dropdownSelection: false,
+        limit: 10,
+        offset: 0,
+        totalCount: 0,
+        page: 1
+      }
+    },
+    props: {
+      datasetDetails: {
+        type: Object,
+        default: () => {}
+      },
+    },
 
-        props: {
-            datasetDetails: {
-                type: Object,
-                default: () => {}
-            },
-        },
+    computed: {
+      getRecordsUrl: function() {
+        if (!this.dropdownSelection) {
+          this.defaultModel = propOr('', 'modelName', head(this.models))
+        }
+        const datasetId = propOr('', 'id', this.datasetDetails)
+        return `https://api.blackfynn.io/discover/search/records?datasetId=${datasetId}&model=${this.defaultModel}`
+     }
+    },
 
-        computed: {
-            getRecordsUrl: function() {
-                if (!this.dropdownSelection) {
-                   this.defaultModel = propOr('', 'modelName', head(this.models))
-                }
-                const datasetId = propOr('', 'id', this.datasetDetails)
-                return `https://api.blackfynn.io/discover/search/records?datasetId=${datasetId}&model=${this.defaultModel}`
-            }
+    watch: {
+      getRecordsUrl:{
+       handler: function(val) {
+         if (val) {
+            this.getMetadataRecords()
+         }
+       },
+       immediate: true
+    },
+      datasetDetails: {
+        handler: function(val){
+          if (val) {
+           this.models = propOr([], 'modelCount', this.datasetDetails)
+          }
         },
+        immediate: true
+      }
+    },
 
-        watch: {
-            getRecordsUrl:{
-                handler: function(val) {
-                    if (val) {
-                        this.getMetadataRecords()
-                    }
-                },
-                immediate: true
-            },
-            datasetDetails: {
-                handler: function(val){
-                    if (val) {
-                      this.models = propOr([], 'modelCount', this.datasetDetails)
-                    }
-                },
-                immediate: true
-            }
-        },
-
-        methods: {
-            getMetadataRecords: function(model = '') {
-                this.isLoading = true
-                if (model !== '') {
-                    this.dropdownSelection = true
-                    this.defaultModel = model
-                }
-                this.offset = (this.page - 1) * this.limit
-                this.axios.get(`${this.getRecordsUrl}&limit=${this.limit}&offset=${this.offset}`)
+    methods: {
+      getMetadataRecords: function(model = '') {
+        this.isLoading = true
+        if (model !== '') {
+          this.dropdownSelection = true
+          this.defaultModel = model
+        }
+        this.offset = (this.page - 1) * this.limit
+        this.axios.get(`${this.getRecordsUrl}&limit=${this.limit}&offset=${this.offset}`)
         .then(response => {
            this.isLoading = false
            this.headings = []
@@ -142,31 +140,31 @@ import Pagination from '../Pagination/Pagination.vue'
           // handle error
           this.errorLoading = true
         })
-            },
+      },
 
-            selectPage: function(index) {
-                this.page = index
-                this.getMetadataRecords()
-            }
-        },
-    }
+      selectPage: function(index) {
+        this.page = index
+        this.getMetadataRecords()
+      }
+    },
+}
 </script>
 
 <style lang="scss" scoped>
-    .metadata-table-content {
-      background: #fff;
-      border: 1px solid rgb(228, 231, 237);
-      padding: 16px;
-      margin-top: 20px;
-      margin-bottom: 10px;
-    }
+.metadata-table-content {
+  background: #fff;
+  border: 1px solid rgb(228, 231, 237);
+  padding: 16px;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
 
-    .metadata-table-dropdown {
-        margin-top: 8px;
-        margin-bottom: 5px;
-    }
+.metadata-table-dropdown {
+  margin-top: 8px;
+  margin-bottom: 5px;
+}
 
-    .metadata-table-pagination {
-        margin-bottom: 10px;
-    }
+.metadata-table-pagination {
+  margin-bottom: 10px;
+}
 </style>

--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -81,6 +81,10 @@ import Pagination from '../Pagination/Pagination.vue'
     },
 
     computed: {
+      /**
+       * Url to get records for model
+       * @returns {String}
+       */
       getRecordsUrl: function() {
         if (!this.dropdownSelection) {
           this.defaultModel = propOr('', 'modelName', head(this.models))
@@ -92,6 +96,9 @@ import Pagination from '../Pagination/Pagination.vue'
     },
 
     watch: {
+      /**
+       * Watches getRecordsUrl before making endpoint call
+       */
       getRecordsUrl:{
        handler: function(val) {
          if (val) {
@@ -100,6 +107,9 @@ import Pagination from '../Pagination/Pagination.vue'
        },
        immediate: true
     },
+    /**
+     * Watches datasetDetails object before assigning models array
+     */
       datasetDetails: {
         handler: function(val){
           if (val) {
@@ -111,6 +121,10 @@ import Pagination from '../Pagination/Pagination.vue'
     },
 
     methods: {
+      /**
+       * Gets the metadata records for a dataset
+       * @param {String} model
+       */
       getMetadataRecords: function(model = '') {
         if (model !== '') {
           this.dropdownSelection = true
@@ -138,12 +152,15 @@ import Pagination from '../Pagination/Pagination.vue'
            })
 
         })
-        .catch(error => {
+        .catch(
           // handle error
           this.errorLoading = true
-        })
+        )
       },
 
+      /**
+       * Selects a page for pagination
+       */
       selectPage: function(index) {
         this.page = index
         this.getMetadataRecords()

--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -238,7 +238,6 @@ export default {
         handler(scope)
       }
     },
-
     selectPage(index) {
       this.page = index;
       this.fetchResults(this.searchType, this.searchTerms);


### PR DESCRIPTION
# Description

The purpose of this PR is to add a metadata table that displays all the records for the models in a dataset.

Please note that data is displayed as is in the table, so formatting can be fixed as necessary.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to a dataset on the data portal. You should see a metadata table underneath the files table
2. Select a model from the dropdown. The records data should change in the table based on that model.
3. Select a model that has a large number of records. Pagination should work as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
