### PR TITLE
Fix Pagination Issue

### DIFF
--- a/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
+++ b/dat_core/vue_app/src/components/MetadataTable/MetadataTable.vue
@@ -130,7 +130,9 @@ import Pagination from '../Pagination/Pagination.vue'
           this.dropdownSelection = true
           this.defaultModel = model
         }
-        this.offset = (this.page - 1) * this.limit
+        if (this.page !== 1) {
+          this.offset = this.page - this.limit
+        }
         this.axios.get(`${this.getRecordsUrl}&limit=${this.limit}&offset=${this.offset}`)
         .then(response => {
            this.isLoading = false


### PR DESCRIPTION
# Description

The purpose of this PR is to fix the pagination issue found in the metadata table, where the offset wasn't being set to the appropriate value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to [this dataset](http://localhost:5000/browse/#/datasets/41) and change the model to `GMA-raw`
2. Click on a large number in the pagination ticker, such as `2027`. Open the network tab. The endpoint request should have the offset set to that page value minus the limit value (which is 10).
3. The data in the table should change as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
