### PR TITLE
Site search analytics - use proper library to send analytics

### DIFF
--- a/dat_core/vue_app/src/components/browse/Browse.vue
+++ b/dat_core/vue_app/src/components/browse/Browse.vue
@@ -199,6 +199,16 @@ export default {
     },
   },
 
+  created: function () {
+    if (window.gtag) {
+      const routerBase = pathOr('', ['options', 'base'], this.$router)
+      window.gtag('config', 'UA-143804703-1', {
+        'page_title' : this.$route.name,
+        'page_path': `${routerBase}/#${this.$route.fullPath}`
+      })
+    }
+  },
+
   methods: {
 
     /**

--- a/dat_core/vue_app/src/main.js
+++ b/dat_core/vue_app/src/main.js
@@ -60,11 +60,14 @@ const router = new VueRouter({
 })
 
 // Send google analytics tracking
-router.afterEach((to) => {
-  if (window.ga) {
-    window.ga('set', 'page', to.fullPath)
-    window.ga('send', 'pageview')
+router.beforeEach((to, from, next) => {
+  if (window.gtag) {
+    window.gtag('config', 'UA-143804703-1', {
+      'page_title' : to.name,
+      'page_path': '/browse/#' + to.fullPath
+    })
   }
+  next()
 })
 
 new Vue({

--- a/home/vue_app/src/main.js
+++ b/home/vue_app/src/main.js
@@ -38,11 +38,15 @@ const router = new VueRouter({
 })
 
 // Send google analytics tracking
-router.afterEach((to) => {
-  if (window.ga) {
-    window.ga('set', 'page', to.fullPath)
-    window.ga('send', 'pageview')
+router.beforeEach((to, from, next) => {
+  if (window.gtag) {
+    window.gtag('config', 'UA-143804703-1', {
+      'page_title' : to.name,
+      'page_path': to.fullPath
+    })
   }
+
+  next()
 })
 
 new Vue({

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,6 @@
     {% if config['ENV'] == 'production' %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-143804703-1"></script>
-    {% endif %}
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
@@ -29,6 +28,7 @@
 
         gtag('config', 'UA-143804703-1');
     </script>
+    {% endif %}
 </head>
 
 <body>


### PR DESCRIPTION
# Description

The purpose of this PR is to use the proper library to send analytics. I previously used `ga.js` which is for Google Analytics, but we're using Google Tag Manager, which then sends to Google Analytics itself. Due to this, we need to use the `gtag.js` library.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I was able to see the site search in Google Analytics this time.
![Screen Shot 2019-10-30 at 3 35 54 PM](https://user-images.githubusercontent.com/1493195/67892816-deb3c680-fb2b-11e9-8153-0809b3e2267b.png)
![Screen Shot 2019-10-30 at 3 36 01 PM](https://user-images.githubusercontent.com/1493195/67892817-df4c5d00-fb2b-11e9-97d1-5535f2e981b1.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
