### PR TITLE
Add banner to the header about new site coming soon

### DIFF
--- a/shared/vue_app/src/components/header/Header.vue
+++ b/shared/vue_app/src/components/header/Header.vue
@@ -1,43 +1,49 @@
 <template>
-    <div class="nav">
-        <el-row type="flex" justify="center">
-            <el-col :xs="22" :sm="22" :md="22" :lg="18" :xl="16">
-                <div class="header">
-                    <div class="logo">
-                        <a href="/"><sparc-logo/></a>
-                        <!-- <span class="data-portal-title">Data Portal</span> -->
-                    </div>
-                    <button
-                        class="btn-menu"
-                        @click="menuOpen = true"
-                    >
-                        <i class="el-icon-s-fold"></i>
-                    </button>
-                    <div
-                        class="navigation"
-                        :class="{ 'open': menuOpen }"
-                    >
-                        <div class="mobile-navigation-header">
-                            <sparc-logo
-                                aria-hidden=”true”
-                                role="presentation"
-                            />
-                            <button
-                                class="btn-menu"
-                                @click="menuOpen = false"
-                            >
-                                <i class="el-icon-close"></i>
-                            </button>
+    <div class="header-wrap">
+        <div class="new-site-notice">
+            <p class="heading"><strong>Coming Soon!</strong></p>
+            <p>We are launching a new and improved version of the SPARC Portal featuring an updated user interface, user-friendly documentation, and approximately double the number of datasets.</p>
+        </div>
+        <div class="nav">
+            <el-row type="flex" justify="center">
+                <el-col :xs="22" :sm="22" :md="22" :lg="18" :xl="16">
+                    <div class="header">
+                        <div class="logo">
+                            <a href="/"><sparc-logo/></a>
+                            <!-- <span class="data-portal-title">Data Portal</span> -->
                         </div>
-                        <ul>
-                            <li :key="link.href" v-for="link in links">
-                                <a v-bind:class="{active: link.active}" :href="link.href" @click="changeActiveValue(link.href)">{{ link.title }}</a>
-                            </li>
-                        </ul>
+                        <button
+                            class="btn-menu"
+                            @click="menuOpen = true"
+                        >
+                            <i class="el-icon-s-fold"></i>
+                        </button>
+                        <div
+                            class="navigation"
+                            :class="{ 'open': menuOpen }"
+                        >
+                            <div class="mobile-navigation-header">
+                                <sparc-logo
+                                    aria-hidden=”true”
+                                    role="presentation"
+                                />
+                                <button
+                                    class="btn-menu"
+                                    @click="menuOpen = false"
+                                >
+                                    <i class="el-icon-close"></i>
+                                </button>
+                            </div>
+                            <ul>
+                                <li :key="link.href" v-for="link in links">
+                                    <a v-bind:class="{active: link.active}" :href="link.href" @click="changeActiveValue(link.href)">{{ link.title }}</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
-                </div>
-            </el-col>
-        </el-row>
+                </el-col>
+            </el-row>
+        </div>
     </div>
 </template>
 
@@ -223,5 +229,22 @@
         bottom: 5px;
         margin-left: 5px;
         user-select: none;
+    }
+    .new-site-notice {
+        background: #8300bf;
+        color: #fff;
+        font-size: 14px;
+        line-height: 18px;
+        padding: 8px;
+        text-align: center;
+        p {
+            margin: 0;
+        }
+        .heading {
+            margin-bottom: 8px;
+            @media (min-width: 48em) {
+                margin-bottom: 4px;
+            }
+        }
     }
 </style>


### PR DESCRIPTION
# Description

The purpose of this PR is to add a banner to the header about new site coming soon.

![localhost_5000_(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/1493195/72815374-8e349c80-3c34-11ea-9589-04095821d046.png)

![localhost_5000_(iPhone X) (1)](https://user-images.githubusercontent.com/1493195/72815382-91c82380-3c34-11ea-94e2-0aa5c201536f.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Visit all pages on all viewports and ensure that the coming soon banner appears at the top.
- Ensure that navigation still works on all viewports.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
